### PR TITLE
input入力で英数字のenterバグを修正

### DIFF
--- a/src/components/TodoInput.vue
+++ b/src/components/TodoInput.vue
@@ -3,7 +3,7 @@
         type="text"
         class="new-todo"
         v-model="newTodo"
-        @keypress="addTodo"
+        @keypress.enter="addTodo"
         autofocus autocomplete="off"
         placeholder="What needs to be done"
     >


### PR DESCRIPTION
@keypress.enterに修正。
英数字だと、enterを押す前でもtodoリストに反映されていたので修正しました